### PR TITLE
添加 #105 对应的功能。

### DIFF
--- a/src/SmartSql.AOP/TransactionAttribute.cs
+++ b/src/SmartSql.AOP/TransactionAttribute.cs
@@ -1,25 +1,25 @@
 ﻿using AspectCore.DynamicProxy;
+using Microsoft.Extensions.DependencyInjection;
+using SmartSql.Exceptions;
 using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Text;
 using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
-using SmartSql.Exceptions;
 
 namespace SmartSql.AOP
 {
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Interface, AllowMultiple = true)]
     public class TransactionAttribute : AbstractInterceptorAttribute
     {
         public string Alias { get; set; } = SmartSqlBuilder.DEFAULT_ALIAS;
         public IsolationLevel Level { get; set; } = IsolationLevel.Unspecified;
         public override async Task Invoke(AspectContext context, AspectDelegate next)
         {
-            var sessionStore = context.ServiceProvider.GetSessionStore(Alias);
+            var sessionStore = context.ServiceProvider.GetSessionStore(this.Alias);
             if (sessionStore == null)
             {
-                throw new SmartSqlException($"can not find SmartSql instance by Alias:{Alias}.");
+                throw new SmartSqlException($"can not find SmartSql instance by Alias:{this.Alias}.");
             }
             var inTransaction = sessionStore.LocalSession?.Transaction != null;
             if (inTransaction)
@@ -29,7 +29,7 @@ namespace SmartSql.AOP
 
             using (sessionStore)
             {
-                await sessionStore.Open().TransactionWrapAsync(Level, async () =>
+                await sessionStore.Open().TransactionWrapAsync(this.Level, async () =>
                 {
                     await next.Invoke(context);
                 });

--- a/src/SmartSql.DyRepository/Annotations/UseTransactionAttribute.cs
+++ b/src/SmartSql.DyRepository/Annotations/UseTransactionAttribute.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace SmartSql.DyRepository.Annotations
 {
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Interface, AllowMultiple = false)]
     public class UseTransactionAttribute : Attribute
     {
         public IsolationLevel Level { get; set; } = IsolationLevel.Unspecified;


### PR DESCRIPTION
SmartSql.AOP.TransactionAttribute 可使用在接口、类、方法以及动态仓库上。
SmartSql.DyRepository.Annotations.UseTransactionAttribute 可使用在动态仓库接口和方法上。