### PR TITLE
修复 MYSQL BulkInsert Null值问题。

### DIFF
--- a/src/SmartSql.Bulk.MySql/BulkInsert.cs
+++ b/src/SmartSql.Bulk.MySql/BulkInsert.cs
@@ -16,6 +16,7 @@ namespace SmartSql.Bulk.MySql
 {
     public class BulkInsert : AbstractBulkInsert
     {
+        const string NULL_VALUE = "NULL";
         public BulkInsert(IDbSession dbSession) : base(dbSession)
         {
         }
@@ -85,18 +86,22 @@ namespace SmartSql.Bulk.MySql
                         var originCell = row[dataColumn];
                         if (originCell is DBNull)
                         {
-                            dataBuilder.Append(DBNull.Value);
+                            dataBuilder.Append(NULL_VALUE);
                         }
                         else
                         {
-                            var dateCell = (DateTime) originCell;
+                            var dateCell = (DateTime)originCell;
                             var dateCellTime = dateCell.ToString(DateTimeFormat);
                             dataBuilder.Append(dateCellTime);
                         }
                     }
+                    else if (row[dataColumn] is DBNull || dataColumn.AutoIncrement)
+                    {
+                        dataBuilder.Append(NULL_VALUE);
+                    }
                     else
                     {
-                        var colValStr = dataColumn.AutoIncrement ? "" : row[dataColumn]?.ToString();
+                        var colValStr = row[dataColumn]?.ToString() ?? NULL_VALUE;
                         dataBuilder.Append(colValStr);
                     }
 


### PR DESCRIPTION
在使用SmartSql.Bulk.MySqlConnector 发现，当entity属性值为null 时，写入数据不为null。而是数据类型的默认值。比如 如果是varchar 写入的就是 “”,如果是 datetime 写入的数据就为 0000-00-00 00:00。。


现已修复 MYSQL BulkInsert 。