### PR TITLE
解决中间件排序问题

### DIFF
--- a/src/SmartSql.Test.Unit/PipelineBuilderTest.cs
+++ b/src/SmartSql.Test.Unit/PipelineBuilderTest.cs
@@ -12,13 +12,28 @@ namespace SmartSql.Test.Unit
         [Fact]
         public void Build()
         {
-            //var pipeline = new PipelineBuilder()
-            //       .Add(new InitializerMiddleware())
-            //       .Add(new PrepareStatementMiddleware())
-            //       .Add(new CachingMiddleware())
-            //       .Add(new CommandExecuterMiddleware(new CommandExecuter()))
-            //       .Add(new ResultHandlerMiddleware())
-            //       .Build();
+            var pipeline = new PipelineBuilder()
+                   .Add(new ResultHandlerMiddleware())
+                   .Add(new PrepareStatementMiddleware())
+                   .Add(new InitializerMiddleware())
+                   .Add(new CachingMiddleware())
+                   .Add(new CommandExecuterMiddleware())
+                   .Add(new DataSourceFilterMiddleware())
+                   .Add(new TransactionMiddleware())
+                   .Build();
+            Assert.Equal(typeof(InitializerMiddleware), pipeline.GetType());
+            IMiddleware middleware = pipeline.Next;
+            Assert.Equal(typeof(PrepareStatementMiddleware), middleware.GetType());
+            middleware = middleware.Next;
+            Assert.Equal(typeof(CachingMiddleware), middleware.GetType());
+            middleware = middleware.Next;
+            Assert.Equal(typeof(TransactionMiddleware), middleware.GetType());
+            middleware = middleware.Next;
+            Assert.Equal(typeof(DataSourceFilterMiddleware), middleware.GetType());
+            middleware = middleware.Next;
+            Assert.Equal(typeof(CommandExecuterMiddleware), middleware.GetType());
+            middleware = middleware.Next;
+            Assert.Equal(typeof(ResultHandlerMiddleware), middleware.GetType());
         }
     }
 }

--- a/src/SmartSql/PipelineBuilder.cs
+++ b/src/SmartSql/PipelineBuilder.cs
@@ -26,16 +26,16 @@ namespace SmartSql
             var list = Pipeline.OrderBy(middleware => middleware.Order).ToList();
             for (var i = 0; i < list.Count; i++)
             {
-                var current = Pipeline[i];
-                if (i == Pipeline.Count - 1)
+                var current = list[i];
+                if (i == list.Count - 1)
                 {
                     break;
                 }
 
-                current.Next = Pipeline[i + 1];
+                current.Next = list[i + 1];
             }
 
-            return Pipeline.FirstOrDefault();
+            return list.FirstOrDefault();
         }
     }
 }


### PR DESCRIPTION
中间件排序后，返回的链表可能不是链表的首节点