### PR TITLE
解决DataBase只有一个Read节点时，而且没有写weight属性，导致权重选择出异常的问题，同时在build xmlConfig时，强制验证Read节点是否写了Weight属性，当Read节点大于2时，其中一个read节点没有写weight属性，直接抛异常

### DIFF
--- a/src/SmartSql.Test.Unit/ConfigBuilder/XmlConfigLoaderTest.cs
+++ b/src/SmartSql.Test.Unit/ConfigBuilder/XmlConfigLoaderTest.cs
@@ -20,7 +20,7 @@ namespace SmartSql.Test.Unit.ConfigBuilder
         {
             try
             {
-                var configLoader = new XmlConfigBuilder(ResourceType.File, "SmartSqlMapConfig.xml");
+                var configLoader = new XmlConfigBuilder(ResourceType.File, "SmartSqlMapConfig2.xml");
                 var config = configLoader.Build();
             }
             catch (SmartSqlException ex)

--- a/src/SmartSql.Test.Unit/ConfigBuilder/XmlConfigLoaderTest.cs
+++ b/src/SmartSql.Test.Unit/ConfigBuilder/XmlConfigLoaderTest.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using SmartSql.ConfigBuilder;
+using SmartSql.Exceptions;
 using Xunit;
 
 namespace SmartSql.Test.Unit.ConfigBuilder
@@ -13,6 +14,19 @@ namespace SmartSql.Test.Unit.ConfigBuilder
         {
             var configLoader = new XmlConfigBuilder(ResourceType.File, "SmartSqlMapConfig.xml");
             var config = configLoader.Build();
+        }
+        [Fact]
+        public void LoadFailTest()
+        {
+            try
+            {
+                var configLoader = new XmlConfigBuilder(ResourceType.File, "SmartSqlMapConfig.xml");
+                var config = configLoader.Build();
+            }
+            catch (SmartSqlException ex)
+            {                  
+                Assert.StartsWith( "Read Nodes must have Weight attribute",ex.Message);
+            }
         }
     }
 }

--- a/src/SmartSql.Test.Unit/SmartSql.Test.Unit.csproj
+++ b/src/SmartSql.Test.Unit/SmartSql.Test.Unit.csproj
@@ -131,6 +131,9 @@
     <None Update="Maps\T_Entity.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="SmartSqlMapConfig2.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="SmartSqlMapConfig.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/src/SmartSql.Test.Unit/SmartSqlMapConfig.xml
+++ b/src/SmartSql.Test.Unit/SmartSqlMapConfig.xml
@@ -53,7 +53,7 @@
         <DbProvider Name="${DbProvider}"/>
         <Write Name="WriteDB" ConnectionString="${ConnectionString}"/>
         <Read Name="ReadDb-1" ConnectionString="${ConnectionString}" Weight="100"/>
-        <Read Name="ReadDb-2" ConnectionString="${ConnectionString}" Weight="100"/>
+        <Read Name="ReadDb-2" ConnectionString="${ConnectionString}"  />
     </Database>
     <TypeHandlers>
         <TypeHandler PropertyType="SmartSql.Test.Entities.UserInfo,SmartSql.Test" Type="${JsonTypeHandler`}">

--- a/src/SmartSql.Test.Unit/SmartSqlMapConfig2.xml
+++ b/src/SmartSql.Test.Unit/SmartSqlMapConfig2.xml
@@ -53,7 +53,7 @@
         <DbProvider Name="${DbProvider}"/>
         <Write Name="WriteDB" ConnectionString="${ConnectionString}"/>
         <Read Name="ReadDb-1" ConnectionString="${ConnectionString}" Weight="100"/>
-        <Read Name="ReadDb-2" ConnectionString="${ConnectionString}"  Weight="100"  />
+        <Read Name="ReadDb-2" ConnectionString="${ConnectionString}"  />
     </Database>
     <TypeHandlers>
         <TypeHandler PropertyType="SmartSql.Test.Entities.UserInfo,SmartSql.Test" Type="${JsonTypeHandler`}">

--- a/src/SmartSql/Utils/DictionaryExtensions.cs
+++ b/src/SmartSql/Utils/DictionaryExtensions.cs
@@ -39,6 +39,13 @@ namespace System.Collections.Generic
                 throw new SmartSqlException($"Can not find Parameter:{key}!");
             }
         }
+        public static void AddRange<TKey, TValue>(this IDictionary<TKey,TValue> dic, IDictionary<TKey,TValue> collection)
+        {
+            foreach(var  item in collection)
+            {
+                dic.Add(item);
+            }
+        }
 
     }
 }

--- a/src/SmartSql/Utils/WeightFilter.cs
+++ b/src/SmartSql/Utils/WeightFilter.cs
@@ -11,6 +11,7 @@ namespace SmartSql.Utils
     /// </summary>
     public class WeightFilter<T>
     {
+        
         /// <summary>
         /// 选举权重源
         /// </summary>
@@ -20,7 +21,16 @@ namespace SmartSql.Utils
         {
             var random = new Random((int)Stopwatch.GetTimestamp());
             var weightSources = inWeightSources.ToList();
-            int totalWeight = weightSources.Sum(source => source.Weight);
+            int totalWeight = 0;
+            if (weightSources.Count ==1)
+            {
+                return weightSources[0];
+            }
+            else
+            {
+              totalWeight=weightSources.Sum(source => source.Weight);
+            }
+       
             int position = random.Next(1, totalWeight);
             return FindByPosition(weightSources, position);
         }


### PR DESCRIPTION
同时在单元测试里面添加一个新的sqlMapXmlConfig文件，用于异常验证