### PR TITLE
修复MYSQL批量插入bool类型的值无法正常转换的问题，并增加对表达式的支持

### DIFF
--- a/src/SmartSql.Bulk.MySql/BulkInsert.cs
+++ b/src/SmartSql.Bulk.MySql/BulkInsert.cs
@@ -1,9 +1,9 @@
 ﻿using SmartSql.DbSession;
 using SmartSql.Reflection.TypeConstants;
 using System;
+using System.Collections.Generic;
 using System.Data;
 using System.IO;
-using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -34,6 +34,7 @@ namespace SmartSql.Bulk.MySql
 
         public String SecureFilePriv { get; set; }
         public String DateTimeFormat { get; set; } = "yyyy-MM-dd HH:mm:ss";
+        public List<string> Expressions { get; } = new List<string>();
         private string _fieldTerminator = ",";
         private char _fieldQuotationCharacter = '"';
         private char _escapeCharacter = '"';
@@ -64,6 +65,8 @@ namespace SmartSql.Bulk.MySql
             {
                 bulkLoader.Columns.Add(dbCol.ColumnName);
             }
+
+            bulkLoader.Expressions.AddRange(Expressions);
 
             return bulkLoader;
         }
@@ -96,6 +99,18 @@ namespace SmartSql.Bulk.MySql
                             var dateCell = (DateTime)originCell;
                             var dateCellTime = dateCell.ToString(DateTimeFormat);
                             dataBuilder.Append(dateCellTime);
+                        }
+                    }
+                    else if (dataColumn.DataType == CommonType.Boolean || dataColumn.DataType == typeof(bool?))
+                    {
+                        var originCell = row[dataColumn];
+                        if (originCell is DBNull)
+                        {
+                            dataBuilder.Append(NULL_VALUE);
+                        }
+                        else
+                        {
+                            dataBuilder.Append(Convert.ToByte(originCell));
                         }
                     }
                     else if (row[dataColumn] is DBNull || dataColumn.AutoIncrement)

--- a/src/SmartSql.Test.Unit/Bulk/MySqlConnectorTest.cs
+++ b/src/SmartSql.Test.Unit/Bulk/MySqlConnectorTest.cs
@@ -1,11 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 using SmartSql.Bulk;
+using SmartSql.Bulk.MySqlConnector;
 using SmartSql.DataSource;
 using SmartSql.Test.Entities;
 using Xunit;
-using SmartSql.Bulk.MySqlConnector;
 
 namespace SmartSql.Test.Unit.Bulk
 {
@@ -19,21 +17,23 @@ namespace SmartSql.Test.Unit.Bulk
                 .UseAlias("MySqlConnectorTest")
                 .Build().GetDbSessionFactory();
 
-            var list = new List<User> {
-                new User {Id = 1, UserName = "1"}
-                , new User {Id = 2, UserName = "2"}
-            };
-            using (var dbSession = dbSessionFactory.Open())
+            var list = new List<User>
             {
-                var data = list.ToDataTable();
-                data.TableName = "t_user";
-                BulkInsert bulkInsert = new BulkInsert(dbSession)
-                {
-                    SecureFilePriv = "C:/ProgramData/MySQL/MySQL Server 8.0/Uploads",
-                    Table = data
-                };
-                bulkInsert.Insert();
-            }
+                new() { Id = 1, UserName = "jack" , IsDelete = true},
+                new() { Id = 2, UserName = "lily", IsDelete = false}
+            };
+            using var dbSession = dbSessionFactory.Open();
+            var data = list.ToDataTable();
+            data.TableName = "t_user";
+            var bulkInsert = new BulkInsert(dbSession)
+            {
+                SecureFilePriv = "C:/ProgramData/MySQL/MySQL Server 8.0/Uploads",
+                Table = data
+            };
+
+            bulkInsert.Expressions.Add("user_name = upper(user_name)");
+            bulkInsert.Expressions.Add("is_delete = convert(is_delete, unsigned )");
+            bulkInsert.Insert();
         }
     }
 }

--- a/src/SmartSql.Test/Entities/User.cs
+++ b/src/SmartSql.Test/Entities/User.cs
@@ -30,9 +30,14 @@ namespace SmartSql.Test.Entities
             Status = status;
         }
 
+        [Column("id")]
         public virtual long Id { get; set; }
+        [Column("user_name")]
         public virtual String UserName { get; set; }
+        [Column("status")]
         public virtual UserStatus Status { get; set; }
+        [Column("is_delete")]
+        public virtual bool IsDelete { get; set; }
     }
 
     public enum UserStatus : Int16


### PR DESCRIPTION
当前MySql的BulkInsert中将DataTable转换为CSV时，会将bool类型的列的值转换为"True"或"False"，通过Load data infile时无法正确的转换成1或0。因此，需要在ToCsV时将bool类型的直接转换为1或0。

同时增加了对表达式的支持。可以使用表达式转换数据。