### PR TITLE
1、为AssemblyAutoRegisterOptions.SmartSqlAlias设置默认值；2、仓储接口注册时，获取ISqlMapper实例都通过IServiceProvider.EnsureSmartSql方法获取

### DIFF
--- a/src/SmartSql.DIExtension/AssemblyAutoRegisterOptions.cs
+++ b/src/SmartSql.DIExtension/AssemblyAutoRegisterOptions.cs
@@ -10,8 +10,8 @@ namespace SmartSql.DIExtension
         /// <summary>
         /// 实例别名
         /// </summary>
-        public String SmartSqlAlias { get; set; }
-        
+        public String SmartSqlAlias { get; set; } = SmartSqlBuilder.DEFAULT_ALIAS;
+
         /// <summary>
         /// Scope模板
         /// 默认：I{Scope}Repository

--- a/src/SmartSql.Test.Unit/DI/DITest.cs
+++ b/src/SmartSql.Test.Unit/DI/DITest.cs
@@ -54,7 +54,7 @@ namespace SmartSql.Test.Unit.DI
         public void AddRepositoryFromAssembly()
         {
             IServiceCollection services = new ServiceCollection();
-            services.AddSmartSql("AddRepositoryFromAssembly")
+            services.AddSmartSql()
                 .AddRepositoryFromAssembly(o =>
                 {
                     o.AssemblyString = "SmartSql.Test";


### PR DESCRIPTION
在注册多数据库实例情况下，如果没有使用UseAlias()方法设置Alias时，会默认使用DEFAULT_ALIAS = "SmartSql"。但是在仓储接口实例化时，通过`sp.GetRequiredService<ISqlMapper>()`方法获取`ISqlMapper`实例就由后注册的`SmartSqlDIBuilder`实例提供。
```
services.AddSingleton<ISqlMapper>(sp => sp.GetRequiredService<SmartSqlBuilder>().SqlMapper);
```

因此将`sp.GetRequiredService<ISqlMapper>()`改成统一使用`SmartSqlBuilder EnsureSmartSql(this IServiceProvider sp, string alias = SmartSqlBuilder.DEFAULT_ALIAS)`方法获取`ISqlMapper`实例，改后的代码即：
```
var sqlMapper = !string.IsNullOrEmpty(options.SmartSqlAlias)
                        ? sp.EnsureSmartSql(options.SmartSqlAlias).SqlMapper
                        : sp.EnsureSmartSql().SqlMapper;
```

为类型`AssemblyAutoRegisterOptions`的属性`SmartSqlAlias`设置默认值，也是为了实现第一个`SmartSqlDIBuilder`实例注册时没有单独指定Alias的时候，也能够正确获取仓储接口实例，与上面的改动都是相同的目的。