### PR TITLE
fix:修复当返回类型为枚举集合时无法获取到`TypeHandler`

### DIFF
--- a/src/SmartSql.Test.Unit/DB/init-mysql-db.sql
+++ b/src/SmartSql.Test.Unit/DB/init-mysql-db.sql
@@ -16,7 +16,7 @@ create table T_AllPrimitive
     String                varchar(100) not null,
     Guid                  char(36)     not null,
     TimeSpan              time         not null,
-    NumericalEnum         tinyint(1)   not null,
+    NumericalEnum         smallint   not null,
     NullableBoolean       tinyint(1)   null,
     NullableChar          char         null,
     NullableInt16         mediumint    null,
@@ -27,7 +27,7 @@ create table T_AllPrimitive
     NullableDateTime      datetime     null,
     NullableGuid          char(36)     null,
     NullableTimeSpan      time         null,
-    NullableNumericalEnum tinyint(1)   null,
+    NullableNumericalEnum smallint   null,
     NullableString        varchar(100) null
 ) engine = InnoDb;
 

--- a/src/SmartSql.Test.Unit/DyRepository/AllPrimitiveRepositoryTest.cs
+++ b/src/SmartSql.Test.Unit/DyRepository/AllPrimitiveRepositoryTest.cs
@@ -1,20 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using SmartSql.Test.Entities;
+using System.Linq;
 using SmartSql.Test.Repositories;
 using Xunit;
-using Microsoft.Extensions.Logging;
-using SmartSql.DyRepository;
 
 namespace SmartSql.Test.Unit.DyRepository
 {
     [Collection("GlobalSmartSql")]
-    public class AllPrimitiveRepositoryTest 
+    public class AllPrimitiveRepositoryTest
     {
-        private IAllPrimitiveRepository _repository;
+        private readonly IAllPrimitiveRepository _repository;
+        private ISqlMapper _mapper;
         public AllPrimitiveRepositoryTest(SmartSqlFixture smartSqlFixture)
         {
             _repository = smartSqlFixture.AllPrimitiveRepository;
+            _mapper = smartSqlFixture.SqlMapper;
         }
 
         [Fact]
@@ -24,7 +23,7 @@ namespace SmartSql.Test.Unit.DyRepository
 
             Assert.NotNull(result);
         }
-        
+
         [Fact]
         public void QueryDictionary()
         {
@@ -32,6 +31,25 @@ namespace SmartSql.Test.Unit.DyRepository
 
             Assert.NotNull(result);
         }
-        
+
+        [Theory]
+        [InlineData(1, NumericalEnum11.One)]
+        [InlineData(2, NumericalEnum11.Two)]
+        public void GetNumericalEnums(int id, NumericalEnum11 numericalEnum)
+        {
+            var list = _mapper.Query<NumericalEnum11?>(new RequestContext
+            {
+                RealSql = "SELECT NumericalEnum FROM T_AllPrimitive WHERE Id = ?id",
+                Request = new { id }
+            });
+
+            Assert.NotNull(list);
+            Assert.True(list.All(t => t == numericalEnum));
+
+            var result = _repository.GetNumericalEnums(id);
+
+            Assert.NotNull(result);
+            Assert.True(result.All(t => t == numericalEnum));
+        }
     }
 }

--- a/src/SmartSql.Test.Unit/SmartSqlFixture.cs
+++ b/src/SmartSql.Test.Unit/SmartSqlFixture.cs
@@ -62,9 +62,13 @@ namespace SmartSql.Test.Unit
 
         protected void InitTestData()
         {
+            AllPrimitiveRepository.Truncate();
             for (int i = 0; i < 10; i++)
             {
-                AllPrimitiveRepository.Insert(new AllPrimitive());
+                AllPrimitiveRepository.Insert(new AllPrimitive()
+                {
+                    NumericalEnum = i % 2 == 0 ? NumericalEnum.One : NumericalEnum.Two
+                });
             }
         }
 

--- a/src/SmartSql.Test.Unit/init-db.sql
+++ b/src/SmartSql.Test.Unit/init-db.sql
@@ -4,8 +4,7 @@ use SmartSqlTestDB;
 
 create table T_AllPrimitive
 (
-    Id                    bigint auto_increment
-        primary key,
+    Id                    bigint auto_increment primary key,
     Boolean               tinyint(1)   not null,
     `Char`                char         not null,
     Int16                 mediumint    not null,
@@ -17,7 +16,7 @@ create table T_AllPrimitive
     String                varchar(100) not null,
     Guid                  char(36)     not null,
     TimeSpan              time         not null,
-    NumericalEnum         tinyint(1)   not null,
+    NumericalEnum         smallint   not null,
     NullableBoolean       tinyint(1)   null,
     NullableChar          char         null,
     NullableInt16         mediumint    null,
@@ -28,10 +27,9 @@ create table T_AllPrimitive
     NullableDateTime      datetime     null,
     NullableGuid          char(36)     null,
     NullableTimeSpan      time         null,
-    NullableNumericalEnum tinyint(1)   null,
+    NullableNumericalEnum smallint   null,
     NullableString        varchar(100) null
-) engine = InnoDb
-;
+) engine = InnoDb;
 
 create table t_column_annotation_entity
 (

--- a/src/SmartSql.Test/Entities/NumericalEnum.cs
+++ b/src/SmartSql.Test/Entities/NumericalEnum.cs
@@ -1,10 +1,14 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace SmartSql.Test.Entities
 {
     public enum NumericalEnum : Byte
+    {
+        One = 1,
+        Two = 2
+    }
+
+    public enum NumericalEnum11 : Byte
     {
         One = 1,
         Two = 2

--- a/src/SmartSql.Test/Repositories/IAllPrimitiveRepository.cs
+++ b/src/SmartSql.Test/Repositories/IAllPrimitiveRepository.cs
@@ -26,6 +26,12 @@ namespace SmartSql.Test.Repositories
         long InsertByAnnotationAOPTransaction(AllPrimitive entity);
 
         [Statement(Id = "QueryDictionary", Sql = "SELECT T.* From T_AllPrimitive T limit ?Taken")]
-        IList<IDictionary<String, Object>> QueryDictionary([Param("Taken")] int taken);
+        IList<IDictionary<string, object>> QueryDictionary([Param("Taken")] int taken);
+
+        [Statement(Sql = "SELECT NumericalEnum FROM T_AllPrimitive WHERE Id = ?id")]
+        List<NumericalEnum11> GetNumericalEnums(int id);
+
+        [Statement(Sql = "truncate table T_AllPrimitive")]
+        void Truncate();
     }
 }


### PR DESCRIPTION
当参数为枚举类型或者参数对象中包含枚举类型的属性时，会自动注册此枚举类型的TypeHandler。
但是如果枚举类型仅作为返回结果集类型时，却没有为其注册TypeHandler。